### PR TITLE
Removed CMake dependency to lib nshalpal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,8 +29,6 @@ include(repositories.cmake)
 
 add_library(mbedRandLib STATIC)
 target_sources(mbedRandLib PRIVATE source/randLIB.c)
-add_dependencies(mbedRandLib nshalpal)
-target_link_libraries(mbedRandLib nshalpal)
 
 target_include_directories(mbedRandLib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/mbed-client-randlib)
 target_include_directories(mbedRandLib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/mbed-client-randlib/platform)

--- a/mbed-client-randlib/platform/arm_hal_random.h
+++ b/mbed-client-randlib/platform/arm_hal_random.h
@@ -15,6 +15,9 @@
  */
 #ifndef ARM_HAL_RANDOM_H_
 #define ARM_HAL_RANDOM_H_
+
+#ifndef EXTERNAL_RANDOM_SEED
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -33,4 +36,7 @@ extern uint32_t arm_random_seed_get(void);
 #ifdef __cplusplus
 }
 #endif
+
+#endif // EXTERNAL_RANDOM_SEED
+
 #endif /* ARM_HAL_RANDOM_H_ */

--- a/source/randLIB.c
+++ b/source/randLIB.c
@@ -42,8 +42,10 @@
 /* RANDLIB_PRNG disables this and forces use of the PRNG (useful for test only?) */
 #ifndef RANDLIB_PRNG
 #ifdef __linux
+#ifndef EXTERNAL_RANDOM_SEED
 #define RANDOM_DEVICE "/dev/urandom"
-#endif
+#endif // EXTERNAL_RANDOM_SEED
+#endif // __linux
 #endif // RANDLIB_PRNG
 
 /* RAM usage - 16 bytes of state (or a FILE * pointer and underlying FILE, which
@@ -82,8 +84,10 @@ static uint64_t splitmix64(uint64_t *seed)
 }
 #endif // RANDOM_DEVICE
 
+
 void randLIB_seed_random(void)
 {
+#ifndef EXTERNAL_RANDOM_SEED
 #ifdef RANDOM_DEVICE
     if (!random_file) {
         random_file = fopen(RANDOM_DEVICE, "rb");
@@ -110,6 +114,7 @@ void randLIB_seed_random(void)
         randLIB_add_seed(state[0]);
     }
 #endif // RANDOM_DEVICE
+#endif // EXTERNAL_RANDOM_SEED
 }
 
 void randLIB_add_seed(uint64_t seed)


### PR DESCRIPTION
Introduced define EXTERNAL_RANDOM_SEED. If it's defined then seed is given to this lib
as early as possible and this lib does not call arm_random_module_init and arm_random_seed_get.

Changes in cloud-client: https://github.com/PelionIoT/mbed-cloud-client-internal/commit/e3d7739397554033916b7c246b95488589b623d4