### PR TITLE
Cmake add interface lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,9 @@ option(enable_coverage_data "Enable Coverage data" OFF)
 include(repositories.cmake)
 
 add_library(mbedRandLib STATIC)
+add_library(mbedRandLibInterface INTERFACE)
+target_include_directories(mbedRandLibInterface INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/mbed-client-randlib)
+
 target_sources(mbedRandLib PRIVATE source/randLIB.c)
 
 target_include_directories(mbedRandLib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/mbed-client-randlib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,21 +48,12 @@ if (test_all OR ${CMAKE_PROJECT_NAME} STREQUAL "mbedRandLib")
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
     endif ()
 
-    add_executable(randlib_test EXCLUDE_FROM_ALL
+    add_executable(randlib_test
         source/randLIB.c
         test/randlib/randlibtest.cpp
         test/randlib/test_randlib.c
         test/stubs/random_stub.c
     )
-
-    # make check, this must be after add_executable!
-    add_test(randlib_test randlib_test)
-    if (TARGET check)
-        add_dependencies(check randlib_test)
-    else()
-        add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND}
-                    DEPENDS randlib_test)
-    endif()
 
     target_compile_options(randlib_test PRIVATE -DRANDLIB_PRNG)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,56 +38,58 @@ target_include_directories(mbedRandLib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/mbed-c
 
 add_definitions(-DINDEPENDENT_RANDLIB)
 
-# Tests after this line
-enable_testing()
+if (test_all OR ${CMAKE_PROJECT_NAME} STREQUAL "mbedRandLib")
+    # Tests after this line
+    enable_testing()
 
-if (enable_coverage_data)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --coverage")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
-endif ()
+    if (enable_coverage_data)
+        set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --coverage")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
+    endif ()
 
-add_executable(randlib_test EXCLUDE_FROM_ALL
-    source/randLIB.c
-    test/randlib/randlibtest.cpp
-    test/randlib/test_randlib.c
-    test/stubs/random_stub.c
-)
-
-# make check, this must be after add_executable!
-add_test(randlib_test randlib_test)
-if (TARGET check)
-    add_dependencies(check randlib_test)
-else()
-    add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND}
-                  DEPENDS randlib_test)
-endif()
-
-target_compile_options(randlib_test PRIVATE -DRANDLIB_PRNG)
-
-target_include_directories(randlib_test PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/mbed-client-randlib)
-target_include_directories(randlib_test PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/)
-target_include_directories(randlib_test PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/test/randlib)
-
-
-target_link_libraries(
-    randlib_test
-    gtest_main
-)
-
-# GTest framework requires C++ version 11
-set_target_properties(randlib_test
-PROPERTIES
-    CXX_STANDARD 11
-)
-
-include(GoogleTest)
-gtest_discover_tests(randlib_test)
-
-if (enable_coverage_data AND ${CMAKE_PROJECT_NAME} STREQUAL mbedRandLib)
-    file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/html")
-
-    add_test(NAME randlib_cov WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        COMMAND ${BASH} -c "gcovr -r . -e ${CMAKE_CURRENT_SOURCE_DIR}/build -e '.*test.*' --html --html-details -o build/html/example-html-details.html"
+    add_executable(randlib_test EXCLUDE_FROM_ALL
+        source/randLIB.c
+        test/randlib/randlibtest.cpp
+        test/randlib/test_randlib.c
+        test/stubs/random_stub.c
     )
+
+    # make check, this must be after add_executable!
+    add_test(randlib_test randlib_test)
+    if (TARGET check)
+        add_dependencies(check randlib_test)
+    else()
+        add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND}
+                    DEPENDS randlib_test)
+    endif()
+
+    target_compile_options(randlib_test PRIVATE -DRANDLIB_PRNG)
+
+    target_include_directories(randlib_test PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/mbed-client-randlib)
+    target_include_directories(randlib_test PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/)
+    target_include_directories(randlib_test PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/test/randlib)
+
+
+    target_link_libraries(
+        randlib_test
+        gtest_main
+    )
+
+    # GTest framework requires C++ version 11
+    set_target_properties(randlib_test
+    PROPERTIES
+        CXX_STANDARD 11
+    )
+
+    include(GoogleTest)
+    gtest_discover_tests(randlib_test)
+
+    if (enable_coverage_data AND ${CMAKE_PROJECT_NAME} STREQUAL mbedRandLib)
+        file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/html")
+
+        add_test(NAME randlib_cov WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+            COMMAND ${BASH} -c "gcovr -r . -e ${CMAKE_CURRENT_SOURCE_DIR}/build -e '.*test.*' --html --html-details -o build/html/example-html-details.html"
+        )
+    endif ()
 endif ()

--- a/run_unit_tests.sh
+++ b/run_unit_tests.sh
@@ -28,7 +28,7 @@ export GTEST_OUTPUT=xml
 mkdir -p ${TEST_DIR}
 cd ${TEST_DIR}
 cmake .. -Denable_coverage_data=ON
-make check
+make all test
 
 # copy produced xml to top level
 cp *.xml ..

--- a/test/README.md
+++ b/test/README.md
@@ -1,8 +1,8 @@
 # Unit tests
 
-You can run unit tests with script `run_unit_tests.sh`. 
+You can run unit tests with script `run_unit_tests.sh`.
 
-The unit tests are implemented with GoogleTest (gtest) C++ test framework. 
+The unit tests are implemented with GoogleTest (gtest) C++ test framework.
 
 ## Prerequisites
 
@@ -18,7 +18,7 @@ sudo apt-get install gcovr
 
 ## Building and running
 
-Prepare unit test build with `cmake ..` and then run the test with `make check` as follows:
+Prepare unit test build with `cmake ..` and then run the test with `make all test` as follows:
 
 ```
 cd nanomesh-applications/libService/exported-libs/mbed-client-randlib
@@ -26,12 +26,12 @@ mkdir build
 cd build
 cmake ..
 
-make check
+make all test
 ```
 
-### Code coverage 
+### Code coverage
 
-Code coverage is optional feature and it is disabled by default. 
+Code coverage is optional feature and it is disabled by default.
 To enable code coverage use the following command to build the tests:
 ```
 cmake .. -Denable_coverage_data=ON

--- a/test/randlib/randlibtest.cpp
+++ b/test/randlib/randlibtest.cpp
@@ -16,12 +16,13 @@
 #include "gtest/gtest.h"
 #include "test_randlib.h"
 
-class randLIB : public testing::Test
-{
-    void SetUp() {
+class randLIB : public testing::Test {
+    void SetUp()
+    {
     }
 
-    void TearDown() {
+    void TearDown()
+    {
     }
 };
 


### PR DESCRIPTION
- exposed mbedRandLibInterface
- limit tests creation only when test_all flag is ON or when cmake from current directory
- do not exclude tests from "make all"
- removed check target